### PR TITLE
Feat: add routes-ssl-acceptor

### DIFF
--- a/easy-routes.lisp
+++ b/easy-routes.lisp
@@ -16,6 +16,10 @@ Just inspect *routes-mapper* from the Lisp listener to see.")
   (:documentation "This acceptors handles routes and only routes. If no route is matched then an HTTP NOT FOUND error is returned.
 If you want to use Hunchentoot easy-handlers dispatch as a fallback, use EASY-ROUTES-ACCEPTOR"))
 
+(defclass routes-ssl-acceptor (routes-acceptor hunchentoot:ssl-acceptor)
+  ()
+  (:documentation "As for ROUTES-ACCEPTOR, but works with the hunchentoot SSL-ACCEPTOR instead."))
+
 (defun acceptor-routes-mapper (acceptor-name)
   (or (getf (gethash acceptor-name *acceptors-routes-and-mappers*)
             :routes-mapper)

--- a/package.lisp
+++ b/package.lisp
@@ -3,6 +3,7 @@
   (:export
    ;; Hunchentoot acceptor
    #:routes-acceptor
+   #:routes-ssl-acceptor
    #:easy-routes-acceptor
    #:easy-routes-ssl-acceptor
    ;; Routes definition


### PR DESCRIPTION
Missing so far but seems obvious that we need it.

Also add `routes-ssl-acceptor` to exported symbols.